### PR TITLE
Cannot parse Nikon Maker tag on D750 produced images.

### DIFF
--- a/Makernotes/nikon.php
+++ b/Makernotes/nikon.php
@@ -32,6 +32,8 @@
 *               Header          10 Bytes         "Nikon\x00\x02\x10\x00\x00"
 *                                               or
 *                                               "Nikon\x00\x02\x00\x00\x00"
+*                                               or
+*                                               "Nikon\x00\x02\x11\x00\x00"
 *               TIFF Data       Variable        TIFF header, with associated
 *                                               Standard IFD Data using, Nikon
 *                                               Type 3 Tags. Offsets are from
@@ -131,7 +133,8 @@ function get_Nikon_Makernote( $Makernote_Tag, $EXIF_Array, $filehnd, $Make_Field
 
         }
         else if ( ( substr( $Makernote_Tag['Data'],0 , 10 ) == "Nikon\x00\x02\x10\x00\x00" ) ||
-                  ( substr( $Makernote_Tag['Data'],0 , 10 ) == "Nikon\x00\x02\x00\x00\x00" ) )
+                  ( substr( $Makernote_Tag['Data'],0 , 10 ) == "Nikon\x00\x02\x00\x00\x00" ) ||
+                  ( substr( $Makernote_Tag['Data'],0 , 10 ) == "Nikon\x00\x02\x11\x00\x00" ) )
         {
                 // Nikon Type 3 Makernote
 


### PR DESCRIPTION
Nikon D750 produces files with the maker note header as Nikon\x00\x02\x11\x00\x00.

Add that to Nikon Type 3 detection, otherwise code falls into else (No header - Nikon Type 2) and fails.

Fixes: https://github.com/evanhunter/PJMT/issues/2